### PR TITLE
chore: log animation start events in Home

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -24,6 +24,20 @@ const Home = () => {
     return () => console.log('[Home] unmounted');
   }, []);
 
+  useEffect(() => {
+    const root = document.querySelector('main, #root, body') || document.body;
+    const onStart = (e: AnimationEvent) => {
+      const t = e.target as HTMLElement;
+      // Only log elements inside the home page
+      if (!root.contains(t)) return;
+      const id = t.id || '';
+      const cls = (t.className || '').toString().trim();
+      console.log('[ANIM start]', e.animationName, { id, cls });
+    };
+    document.addEventListener('animationstart', onStart, true);
+    return () => document.removeEventListener('animationstart', onStart, true);
+  }, []);
+
   const services = [
     {
       icon: <Settings className="h-8 w-8" />,


### PR DESCRIPTION
## Summary
- log CSS animation start events on Home page for debugging

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c5fe8a233483268e1f082b91889ff1